### PR TITLE
#46: add a navigation label override for models

### DIFF
--- a/app/controllers/tolaria/resource_controller.rb
+++ b/app/controllers/tolaria/resource_controller.rb
@@ -32,7 +32,7 @@ class Tolaria::ResourceController < Tolaria::TolariaController
     display_name = Tolaria.display_name(@resource)
 
     if @resource.save
-      flash[:success] = "#{random_blingword} You created the #{@managed_class.model_name.human} “#{display_name}”."
+      flash[:success] = "#{random_blingword} You created the #{@managed_class.navigation_label.singularize} “#{display_name}”."
       return redirect_to form_completion_redirect_path(@managed_class, @resource)
     else
       log_validation_errors!
@@ -54,7 +54,7 @@ class Tolaria::ResourceController < Tolaria::TolariaController
     display_name = Tolaria.display_name(@resource)
 
     if @resource.save
-      flash[:success] = "#{random_blingword} You updated the #{@managed_class.model_name.human.downcase} “#{display_name}”."
+      flash[:success] = "#{random_blingword} You updated the #{@managed_class.navigation_label.singularize.downcase} “#{display_name}”."
       return redirect_to form_completion_redirect_path(@managed_class, @resource)
     else
       log_validation_errors!
@@ -76,7 +76,7 @@ class Tolaria::ResourceController < Tolaria::TolariaController
       return redirect_to form_completion_redirect_path(@managed_class, @resource)
     end
 
-    flash[:destructive] = "You deleted the #{@managed_class.model_name.human.downcase} “#{display_name}”."
+    flash[:destructive] = "You deleted the #{@managed_class.navigation_label.singularize.downcase} “#{display_name}”."
     return redirect_to form_completion_redirect_path(@managed_class)
 
   end

--- a/app/helpers/admin/view_helper.rb
+++ b/app/helpers/admin/view_helper.rb
@@ -55,7 +55,7 @@ module Admin::ViewHelper
 
   # Returns a deletion warning message for the given ActiveRecord instance
   def deletion_warning(resource)
-    return %{Are you sure you want to delete the #{resource.model_name.human.downcase} “#{Tolaria.display_name(resource)}”? This action is not reversible.}
+    return %{Are you sure you want to delete the #{@managed_class.navigation_label.singularize.downcase} “#{Tolaria.display_name(resource)}”? This action is not reversible.}
   end
 
   def contextual_form_url

--- a/app/views/admin/shared/_navigation.html.erb
+++ b/app/views/admin/shared/_navigation.html.erb
@@ -9,7 +9,7 @@
           <% if managed_class.allows?(:index) %>
             <li>
               <%= tolaria_navigation_link(
-                managed_class.model_name.human.pluralize.titleize,
+                managed_class.navigation_label,
                 managed_class.icon,
                 url_for(action:"index", controller:managed_class.plural)
               ) %>

--- a/app/views/admin/tolaria_resource/_index_table.html.erb
+++ b/app/views/admin/tolaria_resource/_index_table.html.erb
@@ -5,13 +5,13 @@
   <div class="blank-slate">
     <span class="blank-slate-icons"><%= fontawesome_icon @managed_class.icon %></span>
     <h3 class="blank-slate-header">
-      No <%= @managed_class.model_name.human.pluralize.titleize %> live here.
+      No <%= @managed_class.navigation_label %> live here.
     </h3>
     <% if @managed_class.allows?(:new) %>
       <p class="blank-slate-text">Get started on the first one:</p>
       <%= link_to url_for(action:"new"), class:"button -primary" do %>
         <%= fontawesome_icon :plus %>
-        New <%= @managed_class.model_name.human.titleize %>
+        New <%= @managed_class.navigation_label.singularize %>
       <% end %>
     <% end %>
   </div>
@@ -23,7 +23,7 @@
   <div class="blank-slate">
     <span class="blank-slate-icons"><%= fontawesome_icon :search %></span>
     <h3 class="blank-slate-header">
-      Your search didn't find any <%= @managed_class.model_name.human.pluralize.titleize %>.
+      Your search didn't find any <%= @managed_class.navigation_label %>.
     </h3>
     <p class="blank-slate-text">
       You can <%= link_to "clear the search form", url_for([:admin, @managed_class.klass]) %>

--- a/app/views/admin/tolaria_resource/_search_form.html.erb
+++ b/app/views/admin/tolaria_resource/_search_form.html.erb
@@ -19,7 +19,7 @@
     <div class="search-form-controlls">
       <%= f.button type:"submit", class:"button -primary", name:nil do %>
         <%= fontawesome_icon :search %>
-        Search <%= @managed_class.model_name.human.pluralize.titleize %>
+        Search <%= @managed_class.navigation_label %>
       <% end %>
       <%= link_to url_for([:admin, @managed_class.klass]), class:"button" do %>
         <%= fontawesome_icon :close %>

--- a/app/views/admin/tolaria_resource/_show_buttons.html.erb
+++ b/app/views/admin/tolaria_resource/_show_buttons.html.erb
@@ -8,6 +8,6 @@
 <% if @managed_class.allows?(:edit) %>
   <%= link_to url_for(action:"edit", id:@resource.id), class:"button -primary" do %>
     <%= fontawesome_icon :pencil %>
-    Edit This <%= @managed_class.model_name.human.titleize %>
+    Edit This <%= @managed_class.navigation_label.singularize %>
   <% end %>
 <% end %>

--- a/app/views/admin/tolaria_resource/edit.html.erb
+++ b/app/views/admin/tolaria_resource/edit.html.erb
@@ -1,7 +1,7 @@
 <% if @resource.persisted? %>
   <%= content_for :title, "#{Tolaria.display_name(@resource)}" %>
 <% else %>
-  <%= content_for :title, "New #{@managed_class.model_name.human.titleize}" %>
+  <%= content_for :title, "New #{@managed_class.navigation_label.singularize}" %>
 <% end %>
 
 <%= form_for [:admin, @resource], url:contextual_form_url, builder:Admin::FormBuilder, html:{class:"resource-form"}  do |form_builder| %>
@@ -18,9 +18,9 @@
         <span class="crumb">
           <%= fontawesome_icon @managed_class.icon %>
           <% if @managed_class.allows? :index %>
-            <%= link_to @managed_class.model_name.human.pluralize.titleize, url_for(action:"index", controller:@managed_class.plural, q:params[:q]) %>
+            <%= link_to @managed_class.navigation_label, url_for(action:"index", controller:@managed_class.plural, q:params[:q]) %>
           <% else %>
-            <%= @managed_class.model_name.human.pluralize.titleize %>
+            <%= @managed_class.navigation_label %>
           <% end %>
         </span>
         <%= content_for :title %>

--- a/app/views/admin/tolaria_resource/index.html.erb
+++ b/app/views/admin/tolaria_resource/index.html.erb
@@ -1,4 +1,4 @@
-<%= content_for :title, "#{@managed_class.model_name.human.pluralize.titleize}" %>
+<%= content_for :title, "#{@managed_class.navigation_label}" %>
 
 <div class="main-controls">
 
@@ -28,7 +28,7 @@
     <% if @managed_class.allows?(:new) %>
       <%= link_to url_for(action:"new", q:params[:q]), class:"button -primary" do %>
         <%= fontawesome_icon :plus %>
-        New <%= @managed_class.model_name.human.titleize %>
+        New <%= @managed_class.navigation_label.singularize %>
       <% end %>
     <% end %>
 

--- a/app/views/admin/tolaria_resource/show.html.erb
+++ b/app/views/admin/tolaria_resource/show.html.erb
@@ -7,9 +7,9 @@
       <span class="crumb">
         <%= fontawesome_icon @managed_class.icon %>
         <% if @managed_class.allows? :index %>
-          <%= link_to @managed_class.model_name.human.pluralize.titleize, url_for(action:"index", controller:@managed_class.plural, q:params[:q]) %>
+          <%= link_to @managed_class.navigation_label, url_for(action:"index", controller:@managed_class.plural, q:params[:q]) %>
         <% else %>
-          <%= @managed_class.model_name.human.pluralize.titleize %>
+          <%= @managed_class.navigation_label %>
         <% end %>
       </span>
       <%= content_for :title %>

--- a/lib/tolaria/active_record.rb
+++ b/lib/tolaria/active_record.rb
@@ -36,6 +36,8 @@ class ActiveRecord::Base
   #   Tolaria will pass this array as the `only:` option to the router.
   #   The default includes all CRUD actions:
   #   `[:index, :show, :new, :create, :edit, :update, :destroy]`
+  # - `:navigation_label` - The navigation label to use for this resource.
+  #   The default is `self.model_name.human.pluralize.titleize`.
   #
   # #### Example
   #

--- a/lib/tolaria/active_record.rb
+++ b/lib/tolaria/active_record.rb
@@ -36,8 +36,9 @@ class ActiveRecord::Base
   #   Tolaria will pass this array as the `only:` option to the router.
   #   The default includes all CRUD actions:
   #   `[:index, :show, :new, :create, :edit, :update, :destroy]`
-  # - `:navigation_label` - The navigation label to use for this resource.
-  #   The default is `self.model_name.human.pluralize.titleize`.
+  # - `:navigation_label` - By default, Tolaria will label buttons, headers, and other view elements for 
+  #   this model using the string obtained from `self.model_name.human.pluralize.titleize`. 
+  #   This setting provides an override label that Tolaria will use instead. 
   #
   # #### Example
   #

--- a/lib/tolaria/managed_class.rb
+++ b/lib/tolaria/managed_class.rb
@@ -34,9 +34,12 @@ module Tolaria
     # A stored symbol for the `params.permit` key for this resource
     attr_accessor :param_key
 
+    # A String to override the model's label in the primary admin navigation
+    attr_accessor :navigation_label
+
     # A factory method that registers a new model in Tolaria and configures
     # its menu and param settings. Developers should use `ActiveRecord::Base.manage_with_tolaria`
-    def self.create(klass, icon:"file-o", permit_params:[], priority:10, category:"Settings", default_order:"id DESC", paginated:true, allowed_actions:[:index, :show, :new, :create, :edit, :update, :destroy])
+    def self.create(klass, icon:"file-o", permit_params:[], priority:10, category:"Settings", default_order:"id DESC", paginated:true, allowed_actions:[:index, :show, :new, :create, :edit, :update, :destroy], navigation_label: klass.model_name.human.pluralize.titleize)
 
       managed_class = self.new
       managed_class.klass = klass
@@ -49,6 +52,7 @@ module Tolaria
       managed_class.paginated = paginated.present?
       managed_class.permitted_params = permit_params.freeze
       managed_class.allowed_actions = allowed_actions.freeze
+      managed_class.navigation_label = navigation_label.freeze
 
       # Set auto-generated attributes
       managed_class.controller_name = "#{managed_class.model_name.collection.camelize}Controller".freeze

--- a/test/demo/app/models/video.rb
+++ b/test/demo/app/models/video.rb
@@ -4,11 +4,12 @@ class Video < ActiveRecord::Base
   validates_presence_of :youtube_id
 
   manage_with_tolaria using:{
+    navigation_label: "YouTube Videos",
     icon: "youtube-play",
     category: "Media",
     permit_params: [
       :title,
-      :yotube_id,
+      :youtube_id,
       :description,
     ],
   }

--- a/test/integration/navigation_label_test.rb
+++ b/test/integration/navigation_label_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class NavigationLabelTest < ActionDispatch::IntegrationTest
+
+  def setup
+    Video.destroy_all
+  end
+
+  def teardown
+    Video.destroy_all
+  end
+
+  test "navigation label is overidden" do
+
+    sign_in_dummy_administrator!
+
+    # index view is overridden
+    visit("/admin/videos")
+    assert page.has_content?("YouTube Videos")
+    assert page.has_content?("New YouTube Video")
+    assert page.has_content?("No YouTube Videos live here")
+
+    # new/edit view is overriden
+    first(".button.-primary").click
+    assert page.has_content?("New YouTube Video")
+    fill_in("video[title]", with:"Neko Atsume")
+    fill_in("video[youtube_id]", with:"xxxxxxxxxxx")
+    first(".button[name=save]").click
+
+    # created flash message is overridden
+    assert page.has_content?("created the YouTube Video"), "should see flash message"
+
+    # show view is overriden
+    find_link("Inspect").click
+    assert page.has_content?("YouTube Videos")
+    assert page.has_content?("Edit This YouTube Video")
+
+    # updated flash message is overriden
+    first(".button.-primary").click
+    first(".button[name=save]").click
+    assert page.has_content?("updated the youtube video"), "should see flash message"
+
+  end
+
+end

--- a/test/unit/managed_classes_test.rb
+++ b/test/unit/managed_classes_test.rb
@@ -6,6 +6,7 @@ class ManagedClassesTest < ActiveSupport::TestCase
 
     class ::Card < ActiveRecord::Base
       manage_with_tolaria using:{
+        navigation_label: "Widgets",
         icon: "credit-card",
         priority: 5,
         category: "Payments",
@@ -31,6 +32,9 @@ class ManagedClassesTest < ActiveSupport::TestCase
     assert_equal managed_class.default_order, "id DESC"
     assert_equal managed_class.allowed_actions, [:index, :show]
     assert managed_class.paginated, true
+
+    # Can we override the navigation label?
+    assert_equal managed_class.navigation_label, "Widgets"
 
     # Can we check action allowances?
     assert managed_class.allows?(:index), "should allow `index` action"


### PR DESCRIPTION
Adds the `navigation_label` option to `manage_with_tolaria` along with a basic unit test. Also updates all breadcrumbs, action buttons, and flash messages to honor this option.
