### PR TITLE
fix: use custom display label with sort column functionality

### DIFF
--- a/app/helpers/admin/table_helper.rb
+++ b/app/helpers/admin/table_helper.rb
@@ -95,7 +95,7 @@ module Admin::TableHelper
     end
 
     if sort.is_a?(Symbol)
-      return content_tag(:th, sort_link(@search, sort), class:"index-th")
+      return content_tag(:th, sort_link(@search, sort, display_label), class:"index-th")
     end
 
     if sort.eql?(true) && field_or_label.is_a?(Symbol)


### PR DESCRIPTION
I think the intention here is to use a custom label for the sort column if you don't want to use the name of the database column, but the `sort_link` method is missing the custom label argument. This PR would add the custom label so it displays as intended.